### PR TITLE
Implement sidebar and dialogue UI

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,10 +1,65 @@
-/* css/style.css */
-html,body{margin:0;height:100%;background:#111;color:#eee;font-family:sans-serif}
-#sidebar{width:250px;overflow-y:auto;background:#222;padding:1rem;float:left;height:100%}
-#main{margin-left:250px;display:flex;flex-direction:column;height:100%}
-#dialog{flex:1;padding:2rem;font-size:1.2rem;line-height:1.5}
-#choices button{display:block;margin:.5rem 0;width:100%}
-#settingsBtn{align-self:flex-end;margin:1rem}
+/* layout */
+#sidebar{
+  position:fixed; left:0; top:0; bottom:0; width:260px;
+  background:#232323; color:#eaeaea; display:flex; flex-direction:column;
+  font-family:"Inter",sans-serif; box-shadow:2px 0 8px #0007;
+}
+#sidebar h2{margin:.5rem 0; font-size:1rem; color:#79f2ff; letter-spacing:.04em}
+
+/* scrollable panes */
+#history,#inventory{flex:1 1 120px; overflow-y:auto; margin:.5rem 0 .75rem .25rem}
+#history a{display:block; padding:.25rem .5rem; border-radius:4px; cursor:pointer}
+#history a:hover{background:#2f2f2f}
+#inventory li{display:flex; align-items:center; gap:.5rem; margin:.25rem 0}
+
+/* stats */
+#stats{padding:.25rem .5rem; background:#1b1b1b; border-radius:6px}
+#stats .row{display:flex; justify-content:space-between; margin:.25rem 0}
+#stats .danger{color:#ff6b6b} .warning{color:#f3c969} .good{color:#a2ff86}
+
+/* clock */
+#clock{margin:.5rem 0; text-align:center; font-size:.9rem; letter-spacing:.05em}
+
+/* action buttons */
+#actions button{
+  width:100%; margin:.25rem 0; padding:.4rem .5rem; border:none; border-radius:4px;
+  background:#3a3a3a; color:#fff; cursor:pointer; transition:background .15s
+}
+#actions button:hover{background:#4b7bec}
+
+#dialogueBox{
+  position:fixed; left:260px; right:0; bottom:0; height:30vh;
+  display:flex; background:#1d1d25ee; backdrop-filter:blur(6px);
+  border-top:2px solid #79f2ff; padding:1.2rem; box-sizing:border-box;
+  font-family:"Merriweather",serif; color:#e8e6ff
+}
+#portrait{
+  width:22%; background-size:contain; background-repeat:no-repeat; background-position:center;
+  border-right:2px solid #444; margin-right:1rem
+}
+#textPanel{flex:1; display:flex; flex-direction:column}
+#nameBar{
+  font-weight:bold; font-size:1rem; text-transform:uppercase; letter-spacing:.05em;
+  margin-bottom:.6rem; color:#79f2ff
+}
+#text{flex:1; line-height:1.55; font-size:1.05rem; overflow-y:auto}
+#continueHint{
+  align-self:flex-end; font-size:1.4rem; opacity:0;
+  animation:blink 1.2s infinite step-end; margin-left:.5rem
+}
+@keyframes blink{ 0%{opacity:0} 50%{opacity:1} 100%{opacity:0} }
+
+#choices{
+  position:fixed; left:260px; right:0; bottom:30vh;
+  display:flex; flex-direction:column; gap:.5rem; padding:0 1.6rem 1rem
+}
+#choices button{
+  background:#2d2d3a; color:#fff; border:none; padding:.6rem 1rem;
+  border-radius:6px; font-size:1rem; text-align:left; transition:transform .15s,background .15s
+}
+#choices button:hover{background:#4b7bec; transform:translateX(3px)}
+
+#settingsBtn{position:fixed; top:.5rem; right:.5rem}
 .modal{position:fixed;inset:0;background:#000a;display:none;align-items:center;justify-content:center}
 .modal .panel{background:#222;padding:1.5rem;border:1px solid #555;width:240px;text-align:center}
 .modal .panel button{margin:.5rem 0;width:100%}

--- a/data/items.json
+++ b/data/items.json
@@ -1,0 +1,3 @@
+{
+  "potion": {"name": "Healing Potion", "icon": "🧪", "desc": "Restores a bit of HP"}
+}

--- a/data/metadata.json
+++ b/data/metadata.json
@@ -1,0 +1,3 @@
+{
+  "title": "Hybrid VN / IF Demo"
+}

--- a/index.html
+++ b/index.html
@@ -7,10 +7,28 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-  <aside id="sidebar"></aside>
+  <aside id="sidebar">
+    <h2 id="gameTitle"></h2>
+    <div id="history"></div>
+    <ul id="inventory"></ul>
+    <div id="stats"></div>
+    <div id="clock"></div>
+    <div id="actions">
+      <button id="actionSave">Save</button>
+      <button id="actionLoad">Load</button>
+      <button id="actionSettings">Settings</button>
+    </div>
+  </aside>
 
   <section id="main">
-    <div id="dialog"></div>
+    <div id="dialogueBox" class="fade">
+      <div id="portrait"></div>
+      <div id="textPanel">
+        <div id="nameBar"></div>
+        <div id="text"></div>
+      </div>
+      <div id="continueHint">▶</div>
+    </div>
     <div id="choices"></div>
     <button id="settingsBtn">⚙️</button>
   </section>

--- a/js/main.js
+++ b/js/main.js
@@ -4,11 +4,16 @@ import { render } from './ui.js';
 
 const state = loadSave() || initialState();
 let scenes = {};
+let characters = {};
+let items = {};
+let metadata = {};
 
 async function loadData(){
   scenes = await (await fetch('data/scenes.json')).json();
-  await fetch('data/characters.json');               // placeholder; expand as needed
-  render(state, scenes);
+  characters = await (await fetch('data/characters.json')).json();
+  metadata = await (await fetch('data/metadata.json')).json();
+  items = await (await fetch('data/items.json')).json();
+  render(state, scenes, characters, items, metadata);
 }
 
 function toggleModal(show){
@@ -21,15 +26,22 @@ document.getElementById('modalClose').onclick = () => toggleModal(false);
 document.getElementById('modalSave').onclick = () => { save(state); toggleModal(false); };
 document.getElementById('modalLoad').onclick = () => {
   const s = loadSave();
-  if(s){ Object.assign(state, s); render(state, scenes); }
+  if(s){ Object.assign(state, s); render(state, scenes, characters, items, metadata); }
   toggleModal(false);
 };
 document.getElementById('modalRestart').onclick = () => {
   Object.assign(state, initialState());
-  render(state, scenes);
+  render(state, scenes, characters, items, metadata);
   toggleModal(false);
 };
 document.getElementById('modalQuit').onclick = () => location.reload();
+
+document.getElementById('actionSave').onclick = () => save(state);
+document.getElementById('actionLoad').onclick = () => {
+  const s = loadSave();
+  if(s){ Object.assign(state, s); render(state, scenes, characters, items, metadata); }
+};
+document.getElementById('actionSettings').onclick = () => toggleModal(true);
 
 window.addEventListener('beforeunload', ()=> save(state)); // autosave on tab close
 loadData();

--- a/js/state.js
+++ b/js/state.js
@@ -4,9 +4,9 @@ export const SAVE_KEY = 'HybridIF_save';
 export function initialState(){
   return {
     scene: 'prologue',
-    flags: {},
-    stats: { hp: 10, xp: 0 },
-    inventory: []
+    flags: { time: 'Day 1 - Morning' },
+    stats: { hp: 100, xp: 0, gold: 5, affection: 50 },
+    inventory: ['potion']
   };
 }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,17 +1,132 @@
 // js/ui.js
-export function render(state, scenes){
-  const d = document.getElementById('dialog');
-  const c = document.getElementById('choices');
-  const s = scenes[state.scene];
+let historyList = [];
+let gScenes, gCharacters, gItems, gMetadata;
 
-  d.innerHTML = s.text.join('<br>');
-  c.innerHTML = '';
-
-  s.choices.forEach(ch=>{
-    const btn = document.createElement('button');
-    btn.textContent = ch.label;
-    btn.onclick = ch.action ? () => { ch.action(state); render(state, scenes);} :
-                              () => { state.scene = ch.goto; render(state, scenes); };
-    c.appendChild(btn);
+function typeText(el, text){
+  return new Promise(resolve => {
+    el.textContent = '';
+    let i = 0;
+    const timer = setInterval(()=>{
+      el.textContent += text[i];
+      i++;
+      if(i >= text.length){
+        clearInterval(timer);
+        resolve();
+      }
+    }, 30);
+    function skip(){
+      clearInterval(timer);
+      el.textContent = text;
+      el.removeEventListener('click', skip);
+      document.removeEventListener('keydown', keySkip);
+      resolve();
+    }
+    function keySkip(e){ if(e.code === 'Space'){ skip(); }}
+    el.addEventListener('click', skip);
+    document.addEventListener('keydown', keySkip);
   });
 }
+
+function updateHistory(state, scenes, container, allow){
+  if(historyList[historyList.length-1] !== state.scene){
+    historyList.push(state.scene);
+  }
+  container.innerHTML = '';
+  historyList.forEach(sceneName =>{
+    const a = document.createElement('a');
+    a.textContent = sceneName;
+    if(allow){
+      a.onclick = () => { state.scene = sceneName; historyList=[]; render(state, gScenes, gCharacters, gItems, gMetadata); };
+    }else{
+      a.style.pointerEvents = 'none';
+      a.style.opacity = '0.5';
+    }
+    container.appendChild(a);
+  });
+}
+
+function updateInventory(state, items, container){
+  container.innerHTML = '';
+  if(!state.inventory || state.inventory.length===0){
+    const li = document.createElement('li');
+    li.textContent = 'None';
+    container.appendChild(li);
+    return;
+  }
+  state.inventory.forEach(id=>{
+    const info = items[id] || {name:id, icon:'', desc:''};
+    const li = document.createElement('li');
+    const span = document.createElement('span');
+    span.textContent = info.icon;
+    li.appendChild(span);
+    li.append(info.name);
+    li.title = info.desc;
+    container.appendChild(li);
+  });
+}
+
+function updateStats(state, container){
+  container.innerHTML = '';
+  Object.entries(state.stats).forEach(([k,v])=>{
+    const row = document.createElement('div');
+    row.className = 'row';
+    const name = document.createElement('span');
+    name.textContent = k.toUpperCase();
+    const val = document.createElement('span');
+    val.textContent = v;
+    if(v < 25) val.classList.add('danger');
+    else if(v < 50) val.classList.add('warning');
+    else val.classList.add('good');
+    row.appendChild(name); row.appendChild(val);
+    container.appendChild(row);
+  });
+}
+
+export async function render(state, scenes, characters={}, items={}, metadata={}){
+  gScenes = scenes; gCharacters = characters; gItems = items; gMetadata = metadata;
+  document.getElementById('gameTitle').textContent = metadata.title || '';
+
+  const historyEl = document.getElementById('history');
+  updateHistory(state, scenes, historyEl, false);
+  const invEl = document.getElementById('inventory');
+  updateInventory(state, items, invEl);
+  const statsEl = document.getElementById('stats');
+  updateStats(state, statsEl);
+  const clockEl = document.getElementById('clock');
+  clockEl.textContent = state.flags.time || '';
+
+  const s = scenes[state.scene];
+  const nameBar = document.getElementById('nameBar');
+  const textEl = document.getElementById('text');
+  const portrait = document.getElementById('portrait');
+  const continueHint = document.getElementById('continueHint');
+  continueHint.style.opacity = '0';
+
+  // naive speaker detection
+  let speaker = '';
+  if(s.text.length && s.text[0].includes(':')){
+    speaker = s.text[0].split(':')[0].replace(/<[^>]+>/g,'');
+  }
+  nameBar.textContent = speaker;
+  if(characters[speaker]){
+    portrait.style.backgroundImage = `url(${characters[speaker].portrait})`;
+  }else{
+    portrait.style.backgroundImage = '';
+  }
+
+  await typeText(textEl, s.text.join(' '));
+  continueHint.style.opacity = '1';
+  updateHistory(state, scenes, historyEl, true);
+
+  const choicesEl = document.getElementById('choices');
+  choicesEl.innerHTML = '';
+  s.choices.forEach((ch,i)=>{
+    const btn = document.createElement('button');
+    btn.textContent = ch.label;
+    btn.style.transitionDelay = `${i*200}ms`;
+    btn.onclick = ch.action ? () => { ch.action(state); render(state, scenes, characters, items, metadata); } :
+                             () => { state.scene = ch.goto; render(state, scenes, characters, items, metadata); };
+    choicesEl.appendChild(btn);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add metadata and item data
- build sidebar and dialogue UI structure
- style sidebar and dialogue elements
- load extra data in main script and wire sidebar actions
- implement dialogue typing and sidebar updates

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684638f92dac8332ba42c5470b9d910b