### PR TITLE
Add simple stat-based interaction

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -43,6 +43,8 @@ body.sidebar-closed #choices{left:0;}
   border-top:2px solid #79f2ff; padding:1.2rem; box-sizing:border-box;
   font-family:"Merriweather",serif; color:#e8e6ff;
   transition:left .3s ease;
+  cursor:pointer;
+  user-select:none;
 }
 #portrait{
   width:22%; background-size:contain; background-repeat:no-repeat; background-position:center;
@@ -56,7 +58,8 @@ body.sidebar-closed #choices{left:0;}
 #text{flex:1; line-height:1.55; font-size:1.05rem; overflow-y:auto}
 #continueHint{
   align-self:flex-end; font-size:1.4rem; opacity:0;
-  animation:blink 1.2s infinite step-end; margin-left:.5rem
+  animation:blink 1.2s infinite step-end; margin-left:.5rem;
+  user-select:none;
 }
 @keyframes blink{ 0%{opacity:0} 50%{opacity:1} 100%{opacity:0} }
 

--- a/data/characters.json
+++ b/data/characters.json
@@ -1,7 +1,10 @@
-// data/characters.json
 {
   "Aurora": {
     "portrait": "img/aurora.png",
+    "voice": null
+  },
+  "Trainer": {
+    "portrait": "img/trainer.png",
     "voice": null
   }
 }

--- a/data/items.json
+++ b/data/items.json
@@ -1,3 +1,4 @@
 {
-  "potion": {"name": "Healing Potion", "icon": "🧪", "desc": "Restores a bit of HP"}
+  "potion": {"name": "Healing Potion", "icon": "🧪", "desc": "Restores a bit of HP"},
+  "dagger": {"name": "Iron Dagger", "icon": "\uD83D\uDDE1\uFE0F", "desc": "A basic weapon"}
 }

--- a/data/scenes.json
+++ b/data/scenes.json
@@ -1,4 +1,3 @@
-// data/scenes.json
 {
   "prologue": {
     "text": ["<b>Aurora:</b> Welcome, stranger…"],
@@ -28,8 +27,10 @@
     ]
   },
   "town": {
-    "text": ["The town is quiet but welcoming."],
+    "text": ["The town is quiet but welcoming. Where will you go?"],
     "choices": [
+      { "label": "Visit the training grounds", "goto": "training" },
+      { "label": "Go home", "goto": "bedroom" },
       { "label": "Return to Aurora", "goto": "prologue" }
     ]
   },
@@ -37,6 +38,29 @@
     "text": ["Trees surround you in every direction."],
     "choices": [
       { "label": "Return to Aurora", "goto": "prologue" }
+    ]
+  },
+  "training": {
+    "text": ["<b>Trainer:</b> Ready to put in some work?"],
+    "choices": [
+      { "label": "Absolutely!", "action": "train", "goto": "town" },
+      { "label": "Maybe later.", "goto": "town" }
+    ]
+  },
+  "bedroom": {
+    "text": [
+      "Your small bedroom is tidy.",
+      "A locked chest sits in the corner."
+    ],
+    "choices": [
+      { "label": "Open the chest", "action": "openChest" },
+      { "label": "Return to town", "goto": "town" }
+    ]
+  },
+  "chestOpened": {
+    "text": ["Using the key, you open the chest and find a dagger."],
+    "choices": [
+      { "label": "Take the dagger", "action": "takeDagger" }
     ]
   }
 }

--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
     <div id="actions">
       <button id="actionSave">Save</button>
       <button id="actionLoad">Load</button>
-      <button id="actionSettings">Settings</button>
     </div>
   </aside>
 

--- a/js/main.js
+++ b/js/main.js
@@ -7,12 +7,40 @@ let scenes = {};
 let characters = {};
 let items = {};
 let metadata = {};
+const actions = {
+  train(state){
+    state.stats.xp += 10;
+    state.flags.hasKey = true;
+  },
+  openChest(state){
+    if(state.flags.hasKey){
+      state.scene = 'chestOpened';
+    } else {
+      alert('The chest is locked.');
+    }
+  },
+  takeDagger(state){
+    if(!state.inventory.includes('dagger')){
+      state.inventory.push('dagger');
+    }
+    state.flags.chestOpened = true;
+    state.scene = 'bedroom';
+  }
+};
 
 async function loadData(){
   scenes = await (await fetch('data/scenes.json')).json();
   characters = await (await fetch('data/characters.json')).json();
   metadata = await (await fetch('data/metadata.json')).json();
   items = await (await fetch('data/items.json')).json();
+  // convert action strings to functions
+  Object.values(scenes).forEach(sc=>{
+    (sc.choices||[]).forEach(ch=>{
+      if(typeof ch.action === 'string' && actions[ch.action]){
+        ch.action = actions[ch.action];
+      }
+    });
+  });
   render(state, scenes, characters, items, metadata);
 }
 
@@ -41,7 +69,6 @@ document.getElementById('actionLoad').onclick = () => {
   const s = loadSave();
   if(s){ Object.assign(state, s); render(state, scenes, characters, items, metadata); }
 };
-document.getElementById('actionSettings').onclick = () => toggleModal(true);
 
 document.getElementById('toggleSidebar').onclick = () => {
   document.body.classList.toggle('sidebar-closed');

--- a/js/state.js
+++ b/js/state.js
@@ -4,7 +4,11 @@ export const SAVE_KEY = 'HybridIF_save';
 export function initialState(){
   return {
     scene: 'prologue',
-    flags: { time: 'Day 1 - Morning' },
+    flags: {
+      time: 'Day 1 - Morning',
+      hasKey: false,
+      chestOpened: false
+    },
     stats: { hp: 100, xp: 0, gold: 5, affection: 50 },
     inventory: ['potion']
   };


### PR DESCRIPTION
## Summary
- remove duplicate settings button
- make dialogue box clickable and ignore text selection
- create scenes for training, home, and chest reward
- add basic actions that modify state
- track key and chest status in saved data
- define trainer character and dagger item

## Testing
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('data/scenes.json')); JSON.parse(fs.readFileSync('data/items.json')); JSON.parse(fs.readFileSync('data/characters.json')); console.log('JSON OK');"`

------
https://chatgpt.com/codex/tasks/task_e_6846493239548332aaa2b452cfe84fc2